### PR TITLE
fix: items types: changes on api endpoint impacts newer versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,6 +77,19 @@ api_client.set_default_header(header_name="X-Proxy-Trace", header_value="quartzy
 
 itemsApi = elabapi_python.ItemsApi(api_client)
 itemsTypesApi = elabapi_python.ItemsTypesApi(api_client)
+infoApi = elabapi_python.InfoApi(api_client)
+# compatible up to version 5.3 due to major changes on items templates & categories. See blogpost about eLabFTW 5.3
+info_response = infoApi.get_info()
+info = info_response.to_dict()
+version_int = info.get("elabftw_version_int", 0)
+version = info.get("elabftw_version", "unknown")
+
+if version_int >= 50300:
+    sys.exit(
+        "ERROR: This script is compatible with eLabFTW versions prior to 5.3.\n"
+        f"You are currently using version {version}, which introduced breaking changes in resources categories & templates.\n"
+        "A working version is on the way."
+    )
 
 #########################
 #     Logging Setup     #

--- a/main.py
+++ b/main.py
@@ -78,18 +78,6 @@ api_client.set_default_header(header_name="X-Proxy-Trace", header_value="quartzy
 itemsApi = elabapi_python.ItemsApi(api_client)
 itemsTypesApi = elabapi_python.ItemsTypesApi(api_client)
 infoApi = elabapi_python.InfoApi(api_client)
-# compatible up to version 5.3 due to major changes on items templates & categories. See blogpost about eLabFTW 5.3
-info_response = infoApi.get_info()
-info = info_response.to_dict()
-version_int = info.get("elabftw_version_int", 0)
-version = info.get("elabftw_version", "unknown")
-
-if version_int >= 50300:
-    sys.exit(
-        "ERROR: This script is compatible with eLabFTW versions prior to 5.3.\n"
-        f"You are currently using version {version}, which introduced breaking changes in resources categories & templates.\n"
-        "A working version is on the way."
-    )
 
 #########################
 #     Logging Setup     #
@@ -125,6 +113,23 @@ handle_insecure_flag(args.insecure)
 
 # Set up logging with the verbose flag
 setup_logging(args.verbose)
+
+#################################
+#     Version Compatibility     #
+#################################
+
+# compatible up to version 5.3 due to major changes on items templates & categories. See blogpost about eLabFTW 5.3
+info_response = infoApi.get_info()
+info = info_response.to_dict()
+version_int = info.get("elabftw_version_int", 0)
+version = info.get("elabftw_version", "unknown")
+
+if version_int >= 50300:
+    sys.exit(
+        "ERROR: This script is not compatible with eLabFTW versions after 5.3.\n"
+        f"You are currently using version {version}, which introduced breaking changes in resources categories & templates.\n"
+        "A working version is on the way."
+    )
 
 #########################
 #     Load Categories   #


### PR DESCRIPTION
eLabFTW 5.3 introduced drastic changes in the handling of resource categories (previously item types).
These changes affect the Python client (elabapi_python).
This PR alerts the client for the new 5.3+ API behavior.
Later on will come the one that adds backward-compatibility logic to support existing scripts on 5.2.x and earlier.

<img width="1515" height="124" alt="image" src="https://github.com/user-attachments/assets/95f0624d-93a3-4614-898a-c98cfa1e64b3" />
