### PR TITLE
Docker COPY fix and elabapi ssl verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV UV_CACHE_DIR=/home/nobody/.cache
 
 WORKDIR /home/nobody/app
 
-COPY .python-version pyproject.toml uv.lock main.py utils.py .
+COPY .python-version pyproject.toml uv.lock main.py utils.py ./
 
 # chown is necessary to fix permission issue on cache folder when executing as nobody
 RUN uv sync --frozen && chown -R nobody:nogroup /home/nobody/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13-slim
 
+RUN apt-get update && apt-get upgrade -y && apt-get clean
+
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
 
 ENV HOME=/home/nobody

--- a/main.py
+++ b/main.py
@@ -54,8 +54,7 @@ configuration.api_key["api_key"] = ELABFTW_API_KEY
 configuration.api_key_prefix["api_key"] = "Authorization"
 configuration.host = ELABFTW_HOST_URL
 configuration.debug = False
-# set to True if you have a proper certificate, here it is set to False to ease the test in dev
-configuration.verify_ssl = False
+configuration.verify_ssl = True
 # setup proxy to elabapi client's config
 proxy_url = os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY")
 if proxy_url:
@@ -107,6 +106,7 @@ args = parse_args()
 def handle_insecure_flag(insecure):
     if insecure:
         urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
+        configuration.verify_ssl = False
 
 # Handle the --insecure flag
 handle_insecure_flag(args.insecure)


### PR DESCRIPTION
- Fix docker COPY destination path syntax
- Enable ssl verification for elabapi unless explicitely disabled withe --insecure