### PR TITLE
fix: categories: bump elabapi-python version & fix resources categories

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ logging.debug(f"Total filtered Quartzy items: {len(quartzy_items)}")
 
 # Category Sync
 existing_categories = resourcesCategoriesApi.read_team_resources_categories(TEAM_ID)
-category_id_map = {cat.name: cat.id for cat in existing_categories}
+category_id_map = {cat.title: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
 
 logging.debug("Syncing resources categories...")

--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ logging.debug(f"Total filtered Quartzy items: {len(quartzy_items)}")
 
 # Category Sync
 existing_categories = resourcesCategoriesApi.read_team_resources_categories(TEAM_ID)
-category_id_map = {cat.title: cat.id for cat in existing_categories}
+category_id_map = {cat.name: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
 
 logging.debug("Syncing resources categories...")

--- a/main.py
+++ b/main.py
@@ -117,23 +117,6 @@ def setup_logging(verbose):
 # Set up logging with the verbose flag
 setup_logging(args.verbose)
 
-#################################
-#     Version Compatibility     #
-#################################
-
-# compatible up to version 5.3 due to major changes on items templates & categories. See blogpost about eLabFTW 5.3
-info_response = infoApi.get_info()
-info = info_response.to_dict()
-version_int = info.get("elabftw_version_int", 0)
-version = info.get("elabftw_version", "unknown")
-
-# if version_int >= 50300:
-#     sys.exit(
-#         "ERROR: This script is not compatible with eLabFTW versions after 5.3.\n"
-#         f"You are currently using version {version}, which introduced breaking changes in resources categories & templates.\n"
-#         "A working version is on the way."
-#     )
-
 #########################
 #     Load Categories   #
 #########################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Import and synchronize Quartzy entries into eLabFTW as read only 
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "elabapi-python>=5.2.3",
+    "elabapi-python==5.3.1",
     "python-dotenv>=1.1.1",
     "requests>=2.32.4",
     "tqdm>=4.67.1",

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ def compute_reminder_date(expiration_date_str, auto_reminder):
     return reminder_date.strftime("%Y-%m-%d")
 
 # fetch all quartzy items, while taking into account the pagination
-def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=60, verbose=False):
+def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=80, verbose=False):
     # currently, there are like 45 pages. Can be updated accordingly in the future
     # api doesn't allow fetching only the pages to see how much there are
     from tqdm import tqdm

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -57,7 +57,7 @@ wheels = [
 
 [[package]]
 name = "elabapi-python"
-version = "5.2.3"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -65,9 +65,9 @@ dependencies = [
     { name = "six" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/b8/fe8ebaac7c028174b5e185ba2663a785f99a0296a139c4503da0bb8fde4f/elabapi_python-5.2.3.tar.gz", hash = "sha256:9da3795d5615d500907f19d8f7f36028e89cf915f1a6e89e9b7dd7b27a7b9c0d", size = 111453, upload-time = "2025-07-02T11:08:19.986Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/18/32adea48c3fa8fff79579be149a0b2c28c3db4ce5300c4a64e8db121970a/elabapi_python-5.3.1.tar.gz", hash = "sha256:576849518beb8c2f90164f13e7fbc1778f5522e51a4113bff340c208a56841f2", size = 111925, upload-time = "2025-10-23T14:58:56.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/2a/6719ecf44ed1a250cadb926893bef2a7f6735843ecb5847b6704bb2bb069/elabapi_python-5.2.3-py3-none-any.whl", hash = "sha256:421136d0fe8e3f8444474175803ead5b627ab46efb2b3aee6767c634db929a69", size = 331163, upload-time = "2025-07-02T11:08:18.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0f/49a90a3c0ed3c6012ae76790a3f008c3de73ae778584d20860c8553d6ffa/elabapi_python-5.3.1-py3-none-any.whl", hash = "sha256:09f0ddcb00d6f24cb2326ec4092c6aaf9f4743f98e1af0b7b5cf41a7e960f638", size = 335968, upload-time = "2025-10-23T14:58:55.412Z" },
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "elabapi-python", specifier = ">=5.2.3" },
+    { name = "elabapi-python", specifier = "==5.3.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "tqdm", specifier = ">=4.67.1" },


### PR DESCRIPTION
- Adapt script to the changes from 5.3
- items_types become resources_categories
- version check removed as compatibility is now okay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New command-line options for verbose output and optional SSL verification.
  * New categories get assigned colors automatically.

* **Refactor**
  * Category handling now uses current team categories; items without a matched category are skipped.
  * Removed prior version-compatibility gating for a simpler startup.

* **Chores**
  * API client dependency pinned to a specific version.
* **Performance**
  * Increased data fetch limit to improve synchronization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->