### PR TITLE
fix: improve API client resilience and error handling in Quartzy sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -182,7 +182,7 @@ for category in new_categories:
     # generate random color for category
     color = "#{:06x}".format(random.randint(0, 0xFFFFFF))
     try:
-        _, status, headers = resourcesCategoriesApi.post_team_one_rescat_with_http_info(
+        _, status, resp_headers = resourcesCategoriesApi.post_team_one_rescat_with_http_info(
             TEAM_ID,
             body={"name": category, "color": color}
         )
@@ -190,7 +190,7 @@ for category in new_categories:
         logging.error(f"Failed to create category '{category}': {e}")
         continue
     if status == 201:
-        location = headers.get("Location", "")
+        location = resp_headers.get("Location", "")
         try:
             new_id = int(location.rstrip("/").split("/")[-1])
             category_id_map[category] = new_id

--- a/main.py
+++ b/main.py
@@ -106,10 +106,8 @@ retry_strategy = Retry(
     total=5, # total retries
     backoff_factor=1, # exponential backoff (1, 2, 4, 8 etc.)
     status_forcelist=[500, 502, 503, 504],
-     # retry idempotent methods and PATCH.
-     # avoid retrying POST to prevent duplicate resource creation
-     # if the server processes the request but returns a 5xx.
-    allowed_methods=frozenset({"DELETE", "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "TRACE"}),
+     # do not retry POST methods to prevent duplicate resource creation
+    allowed_methods=frozenset({'GET','PATCH'}),
 )
 
 api_client.rest_client.pool_manager.connection_pool_kw["retries"] = retry_strategy
@@ -276,7 +274,8 @@ logging.debug("Pushing Quartzy Inventory to eLabFTW...")
 existing_qid_map = {}
 
 try:
-    response = itemsApi.read_items(_preload_content=False, limit=1500)
+    # todo: remove limit when eLabFTW instance is upgraded to latest versions: limit is removed when not passed explicitly
+    response = itemsApi.read_items(_preload_content=False, limit=99999)
     items = json.loads(response.data.decode("utf-8"))
 except Exception as e:
     logging.error(f"Failed to fetch existing items: {e}")

--- a/main.py
+++ b/main.py
@@ -106,7 +106,10 @@ retry_strategy = Retry(
     total=5, # total retries
     backoff_factor=1, # exponential backoff (1, 2, 4, 8 etc.)
     status_forcelist=[500, 502, 503, 504],
-    allowed_methods=False, # retry ALL methods including PATCH
+     # retry idempotent methods and PATCH.
+     # avoid retrying POST to prevent duplicate resource creation
+     # if the server processes the request but returns a 5xx.
+    allowed_methods=frozenset({"DELETE", "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "TRACE"}),
 )
 
 api_client.rest_client.pool_manager.connection_pool_kw["retries"] = retry_strategy

--- a/main.py
+++ b/main.py
@@ -16,12 +16,11 @@ import argparse
 import urllib3
 from urllib3.util.retry import Retry
 from dotenv import load_dotenv
-
-load_dotenv()
-
 # convert auto_reminder date from string to date (e.g. "1WEEK" -> date - 1 week)
 # fetch_all_quartzy_items needed as there's pagination logic not inherited from the Public API
 from utils import compute_reminder_date, fetch_all_quartzy_items
+
+load_dotenv()
 
 #########################
 #      API CONFIG       #

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import logging
 from tqdm import tqdm  # as we import 1000+ items, display a progress bar
 import argparse
 import urllib3
+from urllib3.util.retry import Retry
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -49,6 +50,8 @@ TEAM_ID = "current"
 #########################
 
 ELABFTW_HOST_URL = os.getenv('ELABFTW_HOST_URL') or sys.exit('ELABFTW_HOST_URL environment variable not set')
+# normalize host URL to avoid trailing slash which would produce double slashes in generated API paths (e.g. /api/v2//items)
+ELABFTW_HOST_URL = ELABFTW_HOST_URL.rstrip('/')
 ELABFTW_API_KEY = os.getenv('ELABFTW_API_KEY') or sys.exit('ELABFTW_API_KEY environment variable not set')
 
 #########################
@@ -98,6 +101,16 @@ api_client = elabapi_python.ApiClient(configuration)
 api_client.set_default_header(header_name="Authorization", header_value=ELABFTW_API_KEY)
 # filter eLabFTW traffic in mitmproxy
 api_client.set_default_header(header_name="X-Proxy-Trace", header_value="quartzy2elabftw")
+# Configure automatic retries on transient HTTP errors (e.g. brief connection drops, nginx reloads,
+# php-fpm restarts). This prevents the sync job from failing on temporary network/server issues.
+retry_strategy = Retry(
+    total=5, # total retries
+    backoff_factor=1, # exponential backoff (1, 2, 4, 8 etc.)
+    status_forcelist=[500, 502, 503, 504],
+    allowed_methods=False, # retry ALL methods including PATCH
+)
+
+api_client.rest_client.pool_manager.connection_pool_kw["retries"] = retry_strategy
 
 itemsApi = elabapi_python.ItemsApi(api_client)
 resourcesCategoriesApi = elabapi_python.ResourcesCategoriesApi(api_client)
@@ -152,7 +165,11 @@ logging.debug(f"Total filtered Quartzy items: {len(quartzy_items)}")
 #########################
 
 # Category Sync
-existing_categories = resourcesCategoriesApi.read_team_resources_categories(TEAM_ID)
+try:
+    existing_categories = resourcesCategoriesApi.read_team_resources_categories(TEAM_ID)
+except Exception as e:
+    logging.error(f"Failed to fetch resource categories: {e}")
+    sys.exit(1)
 category_id_map = {cat.title: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
 
@@ -164,10 +181,14 @@ for category in new_categories:
         continue
     # generate random color for category
     color = "#{:06x}".format(random.randint(0, 0xFFFFFF))
-    _, status, headers = resourcesCategoriesApi.post_team_one_rescat_with_http_info(
-        TEAM_ID,
-        body={"name": category, "color": color}
-    )
+    try:
+        _, status, headers = resourcesCategoriesApi.post_team_one_rescat_with_http_info(
+            TEAM_ID,
+            body={"name": category, "color": color}
+        )
+    except Exception as e:
+        logging.error(f"Failed to create category '{category}': {e}")
+        continue
     if status == 201:
         location = headers.get("Location", "")
         try:
@@ -252,8 +273,12 @@ def build_metadata(item):
 logging.debug("Pushing Quartzy Inventory to eLabFTW...")
 existing_qid_map = {}
 
-response = itemsApi.read_items(_preload_content=False, limit=1500)  # quartzy data has proven to be more than 1300
-items = json.loads(response.data.decode("utf-8"))
+try:
+    response = itemsApi.read_items(_preload_content=False, limit=1500)
+    items = json.loads(response.data.decode("utf-8"))
+except Exception as e:
+    logging.error(f"Failed to fetch existing items: {e}")
+    sys.exit(1)
 
 for elab_item in items:
     metadata_raw = elab_item.get("metadata")

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ logging.debug(f"Total filtered Quartzy items: {len(quartzy_items)}")
 try:
     existing_categories = resourcesCategoriesApi.read_team_resources_categories(TEAM_ID)
 except Exception as e:
-    logging.error(f"Failed to fetch resource categories: {e}")
+    logging.exception(f"Failed to fetch resource categories: {e}")
     sys.exit(1)
 category_id_map = {cat.title: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
@@ -187,7 +187,7 @@ for category in new_categories:
             body={"name": category, "color": color}
         )
     except Exception as e:
-        logging.error(f"Failed to create category '{category}': {e}")
+        logging.exception(f"Failed to create category '{category}': {e}")
         continue
     if status == 201:
         location = resp_headers.get("Location", "")
@@ -196,9 +196,9 @@ for category in new_categories:
             category_id_map[category] = new_id
             logging.debug(f"Created category: {category} (ID: {new_id})")
         except Exception:
-            logging.error(f"Couldn't parse ID from Location header: {location}")
+            logging.exception(f"Couldn't parse ID from Location header: {location}")
     else:
-        logging.error(f"Failed to create category '{category}', status: {status}")
+        logging.exception(f"Failed to create category '{category}', status: {status}")
 
 def build_metadata(item):
     qid = item.get("id")
@@ -278,7 +278,7 @@ try:
     response = itemsApi.read_items(_preload_content=False, limit=99999)
     items = json.loads(response.data.decode("utf-8"))
 except Exception as e:
-    logging.error(f"Failed to fetch existing items: {e}")
+    logging.exception(f"Failed to fetch existing items: {e}")
     sys.exit(1)
 
 for elab_item in items:
@@ -299,7 +299,7 @@ for elab_item in items:
         else:
             continue
     except Exception as e:
-        logging.error(f"Failed to parse metadata for item ID {elab_item.get('id')}: {e}")
+        logging.exception(f"Failed to parse metadata for item ID {elab_item.get('id')}: {e}")
 
 logging.debug(f"Found {len(existing_qid_map)} existing items with Quartzy ID.")
 
@@ -385,7 +385,7 @@ for item in pbar:
 
             pbar.set_postfix(created=created, updated=updated, refresh=False)
     except Exception as e:
-        logging.error(f"Exception on item '{name}': {e}")
+        logging.exception(f"Exception on item '{name}': {e}")
 
 total = len(quartzy_items)
 

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ retry_strategy = Retry(
     total=5, # total retries
     backoff_factor=1, # exponential backoff (1, 2, 4, 8 etc.)
     status_forcelist=[500, 502, 503, 504],
-     # do not retry POST methods to prevent duplicate resource creation
+    # do not retry POST methods to prevent duplicate resource creation
     allowed_methods=frozenset({'GET','PATCH'}),
 )
 
@@ -198,7 +198,7 @@ for category in new_categories:
         except Exception:
             logging.exception(f"Couldn't parse ID from Location header: {location}")
     else:
-        logging.exception(f"Failed to create category '{category}', status: {status}")
+        logging.error(f"Failed to create category '{category}', status: {status}")
 
 def build_metadata(item):
     qid = item.get("id")


### PR DESCRIPTION
Enhances robustness of the Quartzy -> eLabFTW sync script by adding automatic retries and improved error handling.
To reproduce the issue, nginx was configured to drop connections without sending a response (HTTP 444).
Since the real problem is not handling a permanently broken server but surviving brief connection drops, the sync was tested with a large dataset (~1000 items) while temporarily forcing nginx to return 444 (do it live in the container, and reload nginx). After restoring normal behavior, the script successfully retried failed requests without creating duplicates or losing data.

Changes:
- Normalized `ELABFTW_HOST_URL` to remove trailing slash and prevent malformed API paths (e.g. `/api/v2//items`)
- Configured `urllib3` Retry strategy:
  • Retries up to 5 times
  • Exponential backoff
  • Retries on 500, 502, 503, 504
  • Applies to all HTTP methods (including PATCH)
- Wrapped critical API calls in try/except blocks:
  • Fetching resource categories
  • Creating new categories
  • Fetching existing items
- Added meaningful logging on failure
- Exit early for unrecoverable startup failures

This prevents the sync job from failing due to temporary network issues, nginx reloads, or php-fpm or something restarts, and improves overall reliability when processing large inventories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host URL formatting to avoid malformed API paths.
  * Improved error handling across fetch/create/update flows so failures are logged and non-fatal where possible.

* **Improvements**
  * Added automatic HTTP retry behavior and increased fetch limits for more reliable syncing.
  * Stricter metadata validation; skip updates when no changes detected; preserved locking and clearer progress/verbose logging.

* **New Features**
  * Exposed an additional public API client for direct use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->