### PR TITLE
bug/minor: imports: remove duplicate imports from db

### DIFF
--- a/deduplicate.md
+++ b/deduplicate.md
@@ -1,0 +1,17 @@
+## Deduplicate Quartzy Items Script
+
+This SQL script removes duplicate `items` that share the same **Quartzy ID**.
+
+For each Quartzy ID:
+- The item with the smallest `id` is kept as the canonical entry.
+- All `experiments2items` links referencing duplicate items are reassigned to the canonical item.
+- Duplicate items are then deleted.
+- All operations run inside a single database transaction.
+
+### Usage
+
+From inside MySQL:
+
+```sql
+SOURCE /full/path/to/deduplicate.sql;
+```

--- a/deduplicate.sql
+++ b/deduplicate.sql
@@ -1,7 +1,6 @@
 -- ===============================
 -- DEDUPLICATE QUARTZY ITEMS
 -- ===============================
-SET autocommit = 0;
 START TRANSACTION;
 
 CREATE TEMPORARY TABLE dedup_map AS

--- a/deduplicate.sql
+++ b/deduplicate.sql
@@ -1,0 +1,27 @@
+-- ===============================
+-- DEDUPLICATE QUARTZY ITEMS
+-- ===============================
+SET autocommit = 0;
+START TRANSACTION;
+
+CREATE TEMPORARY TABLE dedup_map AS
+SELECT
+    i.id AS duplicate_id,
+    MIN(i2.id) AS original_id
+FROM items i
+    JOIN items i2
+        ON JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.extra_fields."Quartzy ID".value'))
+        = JSON_UNQUOTE(JSON_EXTRACT(i2.metadata, '$.extra_fields."Quartzy ID".value'))
+WHERE JSON_EXTRACT(i.metadata, '$.extra_fields."Quartzy ID".value') IS NOT NULL
+GROUP BY i.id
+HAVING duplicate_id <> original_id;
+
+UPDATE experiments2items e
+    JOIN dedup_map d ON e.link_id = d.duplicate_id
+    SET e.link_id = d.original_id;
+
+DELETE i
+FROM items i
+JOIN dedup_map d ON i.id = d.duplicate_id;
+
+COMMIT;


### PR DESCRIPTION
This script removes duplicate items (only those related to Quartzy import), from the database. For each Quartzy ID:
- The item with the smallest `id` is kept as the canonical entry.
- All `experiments2items` links referencing duplicate items are reassigned to the canonical item.
- Duplicate items are then deleted.
- All operations run inside a single database transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a database utility to deduplicate items and update related references.

* **Documentation**
  * Added a guide describing how to run the deduplication utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->