### PR TITLE
chore: quartzy: optimize requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,6 +113,16 @@ retry_strategy = Retry(
 )
 
 api_client.rest_client.pool_manager.connection_pool_kw["retries"] = retry_strategy
+# --- request counters (simple global hook) ---
+REQUEST_COUNT = {"GET": 0, "PATCH": 0, "POST": 0, "TOTAL": 0}
+original_request = api_client.rest_client.request
+def counting_request(method, url, *args, **kwargs):
+    method_upper = method.upper()
+    if method_upper in REQUEST_COUNT:
+        REQUEST_COUNT[method_upper] += 1
+    REQUEST_COUNT["TOTAL"] += 1
+    return original_request(method, url, *args, **kwargs)
+api_client.rest_client.request = counting_request
 
 itemsApi = elabapi_python.ItemsApi(api_client)
 resourcesCategoriesApi = elabapi_python.ResourcesCategoriesApi(api_client)
@@ -412,3 +422,10 @@ if updated == 0:
     logging.debug(f"Done: {updated}/{total} item{'s' if total != 1 else ''} needed update.")
 else:
     logging.debug(f"Done: {updated}/{total} item{'s' if updated != 1 else ''} successfully updated.")
+
+if args.verbose:
+    logging.debug("\n--- API CALL STATS ---")
+    logging.debug(f"GET:   {REQUEST_COUNT['GET']}")
+    logging.debug(f"PATCH: {REQUEST_COUNT['PATCH']}")
+    logging.debug(f"POST:  {REQUEST_COUNT['POST']}")
+    logging.debug(f"TOTAL: {REQUEST_COUNT['TOTAL']}")

--- a/main.py
+++ b/main.py
@@ -16,8 +16,6 @@ import argparse
 import urllib3
 from urllib3.util.retry import Retry
 from dotenv import load_dotenv
-# use a hash for the sync reference and prevent useless fetches
-import hashlib
 # convert auto_reminder date from string to date (e.g. "1WEEK" -> date - 1 week)
 # fetch_all_quartzy_items needed as there's pagination logic not inherited from the Public API
 from utils import compute_reminder_date, fetch_all_quartzy_items
@@ -143,6 +141,13 @@ logging.debug(f"Categories allowed : {ALLOWED_CATEGORIES}")
 #   QUARTZY INVENTORY   #
 #########################
 
+def metadata_changed(existing_metadata_raw, new_metadata_dict):
+    existing_metadata = json.loads(existing_metadata_raw) if isinstance(existing_metadata_raw, str) else existing_metadata_raw
+    existing_metadata_json = json.dumps(existing_metadata, sort_keys=True)
+    new_metadata_json = json.dumps(new_metadata_dict, sort_keys=True)
+
+    return existing_metadata_json != new_metadata_json
+
 def normalize_metadata(metadata):
     if not metadata:
         return {}
@@ -150,9 +155,6 @@ def normalize_metadata(metadata):
         metadata = json.loads(metadata)
     extra = metadata.get("extra_fields", {})
     return {k: v for k, v in extra.items() if v.get("value") not in ("", None)}
-
-def compute_metadata_hash(metadata_dict):
-    return hashlib.md5(json.dumps(metadata_dict, sort_keys=True).encode()).hexdigest()
 
 # Quartzy public API authorizations (AccessToken)
 headers = {"Access-Token": QUARTZY_TOKEN, "Accept": "application/json"}
@@ -175,7 +177,6 @@ try:
 except Exception as e:
     logging.exception(f"Failed to fetch resource categories: {e}")
     sys.exit(1)
-
 category_id_map = {cat.title: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
 
@@ -267,10 +268,6 @@ def build_metadata(item):
     # remove fields with no values
     cleaned = {k: v for k, v in extra_fields.items() if v.get("value")}
 
-    # add hash
-    hash_value = compute_metadata_hash({"extra_fields": cleaned})
-    cleaned["Sync Hash"] = {"type": "text", "value": hash_value}
-
     return {"extra_fields": cleaned}
 
 #########################
@@ -352,11 +349,7 @@ for item in pbar:
                 "extra_fields": new_metadata_full.get("extra_fields", {})
             }
 
-            # fast hash check
-            existing_hash = existing_metadata.get("extra_fields", {}).get("Sync Hash", {}).get("value")
-            new_hash = new_metadata_dict["extra_fields"].get("Sync Hash", {}).get("value")
-
-            if existing_hash and new_hash and existing_hash == new_hash:
+            if not metadata_changed(existing_metadata_raw, new_metadata_dict):
                 continue
 
             # safe fallback

--- a/main.py
+++ b/main.py
@@ -16,6 +16,8 @@ import argparse
 import urllib3
 from urllib3.util.retry import Retry
 from dotenv import load_dotenv
+# use a hash for the sync reference and prevent useless fetches
+import hashlib
 # convert auto_reminder date from string to date (e.g. "1WEEK" -> date - 1 week)
 # fetch_all_quartzy_items needed as there's pagination logic not inherited from the Public API
 from utils import compute_reminder_date, fetch_all_quartzy_items
@@ -146,8 +148,18 @@ def metadata_changed(existing_metadata_raw, new_metadata_dict):
     existing_metadata = json.loads(existing_metadata_raw) if isinstance(existing_metadata_raw, str) else existing_metadata_raw
     existing_metadata_json = json.dumps(existing_metadata, sort_keys=True)
     new_metadata_json = json.dumps(new_metadata_dict, sort_keys=True)
-
     return existing_metadata_json != new_metadata_json
+
+def normalize_metadata(metadata):
+    if not metadata:
+        return {}
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+    extra = metadata.get("extra_fields", {})
+    return {k: v for k, v in extra.items() if v.get("value") not in ("", None)}
+
+def compute_metadata_hash(metadata_dict):
+    return hashlib.md5(json.dumps(metadata_dict, sort_keys=True).encode()).hexdigest()
 
 # Quartzy public API authorizations (AccessToken)
 headers = {"Access-Token": QUARTZY_TOKEN, "Accept": "application/json"}
@@ -170,6 +182,7 @@ try:
 except Exception as e:
     logging.exception(f"Failed to fetch resource categories: {e}")
     sys.exit(1)
+
 category_id_map = {cat.title: cat.id for cat in existing_categories}
 new_categories = sorted(set(item["type"]["name"] for item in quartzy_items))
 
@@ -261,11 +274,11 @@ def build_metadata(item):
     # remove fields with no values
     cleaned = {k: v for k, v in extra_fields.items() if v.get("value")}
 
-    if not cleaned:
-        raise ValueError(f"[ERROR] Empty metadata for item: {item.get('name')}")
+    # add hash
+    hash_value = compute_metadata_hash({"extra_fields": cleaned})
+    cleaned["Sync Hash"] = {"type": "text", "value": hash_value}
 
     return {"extra_fields": cleaned}
-
 
 #########################
 #   eLabFTW resources   #
@@ -295,7 +308,7 @@ for elab_item in items:
 
         qid = metadata.get("extra_fields", {}).get("Quartzy ID", {}).get("value")
         if qid:
-            existing_qid_map[qid] = elab_item["id"]
+            existing_qid_map[qid] = elab_item
         else:
             continue
     except Exception as e:
@@ -303,7 +316,6 @@ for elab_item in items:
 
 logging.debug(f"Found {len(existing_qid_map)} existing items with Quartzy ID.")
 
-# Loop
 created, updated = 0, 0
 
 pbar = tqdm(quartzy_items, desc="Syncing Quartzy items", unit="item", disable=not args.verbose)
@@ -332,13 +344,9 @@ for item in pbar:
 
         if qid in existing_qid_map:
             # PATCH existing item
-            item_id = existing_qid_map[qid]
+            existing_item = existing_qid_map[qid]
+            item_id = existing_item["id"]
 
-            # before sending a patch request, check if the data has changed. If not, do not send useless request
-            response = itemsApi.get_item(item_id, _preload_content=False)
-            existing_item = json.loads(response.data.decode("utf-8"))
-
-            # Get and parse existing metadata
             existing_metadata_raw = existing_item.get("metadata")
             existing_metadata = (
                 json.loads(existing_metadata_raw)
@@ -346,14 +354,21 @@ for item in pbar:
                 else existing_metadata_raw
             )
 
-            # Build new metadata dict to compare with existing
+            new_metadata_full = build_metadata(item)
             new_metadata_dict = {
-                "extra_fields": build_metadata(item).get("extra_fields", {})
+                "extra_fields": new_metadata_full.get("extra_fields", {})
             }
 
-            # use metadata_changed function to compare
-            if not metadata_changed(existing_metadata_raw, new_metadata_dict):
-                continue  # Skip patching, no change in metadata
+            # fast hash check
+            existing_hash = existing_metadata.get("extra_fields", {}).get("Sync Hash", {}).get("value")
+            new_hash = new_metadata_dict["extra_fields"].get("Sync Hash", {}).get("value")
+
+            if existing_hash and new_hash and existing_hash == new_hash:
+                continue
+
+            # safe fallback
+            if normalize_metadata(existing_metadata) == normalize_metadata(new_metadata_dict):
+                continue
 
             patch_payload = {
                 "title": item["name"],

--- a/main.py
+++ b/main.py
@@ -262,7 +262,7 @@ def build_metadata(item):
     cleaned = {k: v for k, v in extra_fields.items() if v.get("value")}
 
     if not cleaned:
-            raise ValueError(f"[ERROR] Empty metadata for item: {item.get('name')}")
+        raise ValueError(f"[ERROR] Empty metadata for item: {item.get('name')}")
 
     return {"extra_fields": cleaned}
 

--- a/main.py
+++ b/main.py
@@ -261,6 +261,9 @@ def build_metadata(item):
     # remove fields with no values
     cleaned = {k: v for k, v in extra_fields.items() if v.get("value")}
 
+    if not cleaned:
+            raise ValueError(f"[ERROR] Empty metadata for item: {item.get('name')}")
+
     return {"extra_fields": cleaned}
 
 #########################
@@ -343,7 +346,7 @@ for item in pbar:
             }
 
             if not metadata_changed(existing_metadata_raw, new_metadata_dict):
-                continue # Skip patching, no change in metadata
+                continue  # Skip patching, no change in metadata
 
             patch_payload = {
                 "title": item["name"],

--- a/main.py
+++ b/main.py
@@ -113,16 +113,6 @@ retry_strategy = Retry(
 )
 
 api_client.rest_client.pool_manager.connection_pool_kw["retries"] = retry_strategy
-# --- request counters (simple global hook) ---
-REQUEST_COUNT = {"GET": 0, "PATCH": 0, "POST": 0, "TOTAL": 0}
-original_request = api_client.rest_client.request
-def counting_request(method, url, *args, **kwargs):
-    method_upper = method.upper()
-    if method_upper in REQUEST_COUNT:
-        REQUEST_COUNT[method_upper] += 1
-    REQUEST_COUNT["TOTAL"] += 1
-    return original_request(method, url, *args, **kwargs)
-api_client.rest_client.request = counting_request
 
 itemsApi = elabapi_python.ItemsApi(api_client)
 resourcesCategoriesApi = elabapi_python.ResourcesCategoriesApi(api_client)
@@ -422,10 +412,3 @@ if updated == 0:
     logging.debug(f"Done: {updated}/{total} item{'s' if total != 1 else ''} needed update.")
 else:
     logging.debug(f"Done: {updated}/{total} item{'s' if updated != 1 else ''} successfully updated.")
-
-if args.verbose:
-    logging.debug("\n--- API CALL STATS ---")
-    logging.debug(f"GET:   {REQUEST_COUNT['GET']}")
-    logging.debug(f"PATCH: {REQUEST_COUNT['PATCH']}")
-    logging.debug(f"POST:  {REQUEST_COUNT['POST']}")
-    logging.debug(f"TOTAL: {REQUEST_COUNT['TOTAL']}")

--- a/main.py
+++ b/main.py
@@ -141,20 +141,13 @@ logging.debug(f"Categories allowed : {ALLOWED_CATEGORIES}")
 #   QUARTZY INVENTORY   #
 #########################
 
+# compare existing metadata & incoming metadata
 def metadata_changed(existing_metadata_raw, new_metadata_dict):
     existing_metadata = json.loads(existing_metadata_raw) if isinstance(existing_metadata_raw, str) else existing_metadata_raw
     existing_metadata_json = json.dumps(existing_metadata, sort_keys=True)
     new_metadata_json = json.dumps(new_metadata_dict, sort_keys=True)
 
     return existing_metadata_json != new_metadata_json
-
-def normalize_metadata(metadata):
-    if not metadata:
-        return {}
-    if isinstance(metadata, str):
-        metadata = json.loads(metadata)
-    extra = metadata.get("extra_fields", {})
-    return {k: v for k, v in extra.items() if v.get("value") not in ("", None)}
 
 # Quartzy public API authorizations (AccessToken)
 headers = {"Access-Token": QUARTZY_TOKEN, "Accept": "application/json"}
@@ -350,11 +343,7 @@ for item in pbar:
             }
 
             if not metadata_changed(existing_metadata_raw, new_metadata_dict):
-                continue
-
-            # safe fallback
-            if normalize_metadata(existing_metadata) == normalize_metadata(new_metadata_dict):
-                continue
+                continue # Skip patching, no change in metadata
 
             patch_payload = {
                 "title": item["name"],

--- a/main.py
+++ b/main.py
@@ -143,13 +143,6 @@ logging.debug(f"Categories allowed : {ALLOWED_CATEGORIES}")
 #   QUARTZY INVENTORY   #
 #########################
 
-# compare existing metadata & incoming metadata
-def metadata_changed(existing_metadata_raw, new_metadata_dict):
-    existing_metadata = json.loads(existing_metadata_raw) if isinstance(existing_metadata_raw, str) else existing_metadata_raw
-    existing_metadata_json = json.dumps(existing_metadata, sort_keys=True)
-    new_metadata_json = json.dumps(new_metadata_dict, sort_keys=True)
-    return existing_metadata_json != new_metadata_json
-
 def normalize_metadata(metadata):
     if not metadata:
         return {}

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ def compute_reminder_date(expiration_date_str, auto_reminder):
     return reminder_date.strftime("%Y-%m-%d")
 
 # fetch all quartzy items, while taking into account the pagination
-def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=1, verbose=False):
+def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=80, verbose=False):
     # currently, there are like 45 pages. Can be updated accordingly in the future
     # api doesn't allow fetching only the pages to see how much there are
     from tqdm import tqdm

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ def compute_reminder_date(expiration_date_str, auto_reminder):
     return reminder_date.strftime("%Y-%m-%d")
 
 # fetch all quartzy items, while taking into account the pagination
-def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=80, verbose=False):
+def fetch_all_quartzy_items(api_url, headers, per_page=25, max_pages=1, verbose=False):
     # currently, there are like 45 pages. Can be updated accordingly in the future
     # api doesn't allow fetching only the pages to see how much there are
     from tqdm import tqdm


### PR DESCRIPTION
This pr optimizes Quartzy -> eLabFTW sync to reduce unnecessary API calls.

- remove per-item GET requests by reusing already fetched items
- introduce hash-based comparison (Sync Hash) to detect real metadata changes. Way faster now
- add normalized fallback comparison to ensure correctness
- avoid unnecessary PATCH requests when no actual changes occur

Result: significantly fewer API calls and faster sync execution
The first run will take some time to add the sync hash into the fields, then subsequent ones will show the perf improvement.

Before - 
<img width="480" height="186" alt="Capture d’écran du 2026-04-01 15-04-38" src="https://github.com/user-attachments/assets/13a2c4ba-d792-4fc1-b217-9126ed16eabb" />

- useless patch
- get per each items useless


After - 
<img width="461" height="165" alt="Capture d’écran du 2026-04-01 15-20-25" src="https://github.com/user-attachments/assets/38829c90-3012-4915-8a4e-0976935f8253" />

- 1 get for all items
- no patch if not needed
- sync comparing is way faster




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Performance improvements to internal item processing and lookup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->