### PR TITLE
ci: use shasum for actions

### DIFF
--- a/.github/workflows/push_to_registry.yml
+++ b/.github/workflows/push_to_registry.yml
@@ -10,21 +10,22 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           platforms: linux/amd64
           push: true
           tags: ghcr.io/deltablot/quartzy2elabftw:latest
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker-related actions in the continuous integration workflow to use pinned commit SHAs instead of version tags for consistency and reproducibility in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->